### PR TITLE
pyflakesで検査したエラーに対応した

### DIFF
--- a/newsgroup.py
+++ b/newsgroup.py
@@ -7,6 +7,7 @@ import sys
 import argparse
 import urllib.request
 import nntplib
+import traceback
 from html.parser import HTMLParser
 
 def gmane():
@@ -41,5 +42,5 @@ try:
         fj()
 
 except Exception as e:
-    traceback.print_exc()
-
+    print(e, traceback.format_exc(), file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
```
tree-viewer/newsgroup.py:43:1 local variable 'e' is assigned to but never used
tree-viewer/newsgroup.py:44:5 undefined name 'traceback'
```