### PR TITLE
macosでのコンパイルエラーに対応した

### DIFF
--- a/tree.cpp
+++ b/tree.cpp
@@ -48,7 +48,7 @@ namespace tree {
             si->accept(*this);
         }
     }
+    // Explicit Instance
+    template class ItemVisitor<Path>;
+    template class LineItemVisitor<Path>;
 }
-// Explicit Instance
-template class ItemVisitor<Path>;
-template class LineItemVisitor<Path>;


### PR DESCRIPTION
macosでのコンパイルエラーに対応した
```
macbookair:tree-viewer hideki$ make
g++ -Wall -I. --std=c++11 -c -O3 tree.cpp
tree.cpp:53:16: error: explicit instantiation of 'tree::ItemVisitor' must occur in namespace 'tree'
template class ItemVisitor<Path>;
               ^
./tree.hpp:85:11: note: explicit instantiation refers here
    class ItemVisitor : public Visitor<T> {
          ^
tree.cpp:54:16: error: explicit instantiation of 'tree::LineItemVisitor' must occur in namespace 'tree'
template class LineItemVisitor<Path>;
               ^
./tree.hpp:93:11: note: explicit instantiation refers here
    class LineItemVisitor : public Visitor<T> {
          ^
2 errors generated.
make: *** [tree.o] Error 1
macbookair:tree-viewer hideki$
```